### PR TITLE
Recognize as a ligature four or more dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Fira Code again, but with all ligatures suppressed:<br>
 
  <img src="https://shetline.com/readme/ligatures-limited-ij/v1.0.1/0xF_nolig.png" width="24" height="14" align="absmiddle" style="display: inline-block; position: relative; top: -0.075em" alt="0xF ligature"> represents `0x` followed by any hexadecimal digit, and <img src="https://shetline.com/readme/ligatures-limited-ij/v1.0.1/9x9_nolig.png" width="24" height="14" align="absmiddle" style="display: inline-block; position: relative; top: -0.075em" alt="9x9 ligature"> represents `x` surrounded by any decimal digits. You can specify your own additional ligatures if you need _Ligatures Limited_ to be aware of them.
 
-The bottom row are indefinite-width ligatures. When specifying these ligatures, _three_ equals signs (`=`), dashes (`-`), or tildes (`~`) represent three *or more* of those signs, except for the first three ligatures, where _four_ equals signs represent four or more.
+The bottom row are indefinite-width ligatures. When specifying these ligatures, _three_ equals signs (`=`), dashes (`-`), or tildes (`~`) represent three *or more* of those signs, except for the first three ligatures, where _four_ equals signs represent four or more. Four or more dashes, without a leading `<` or trailing `>`, is also a special case, represented by four dashes.
 
 `####` is another indefinite-width ligature, representing four or more number signs (`#`) in a row.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.shetline"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
   mavenCentral()
@@ -45,6 +45,8 @@ tasks.withType<Jar> {
 
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
   changeNotes("""
+      <h2>1.0.1</h2>
+      <ul><li>Recognize as a ligature four or more dashes, by themselves, without a leading <b>&lt;</b> or trailing <b>&gt;</b>.</ul>
       <h2>1.0.0</h2>
       <ul><li>First stable release</li></ul>
 """

--- a/src/main/kotlin/com/shetline/lligatures/LigaturesLimitedSettings.kt
+++ b/src/main/kotlin/com/shetline/lligatures/LigaturesLimitedSettings.kt
@@ -93,7 +93,7 @@ class LigaturesLimitedSettings : PersistentStateComponent<LigaturesLimitedSettin
   ;; :: ::: .. ... ..< !! ?? %% && <:< || ?. ?: ++ +++ -- --- ** *** ~= ~- www ff fi fl ffi ffl
   -~ ~@ ^= ?= /= /== |= ||= #! ## ### #### #{ #[ ]# #( #? #_ #: #= #_( #{} =~ !~ 9x9 0xF 0o7 0b1
   |- |-- -| --| |== =| ==| /==/ ==/ /=/ <~~> =>= =<= :>: :<: /\ \/ _|_ ||- :< >: ::=
-  <==== ==== ====> <====> <--- ---> <---> |--- ---| |=== ===| /=== ===/ <~~~ ~~~> <~~~>
+  <==== ==== ====> <====> <--- ---- ---> <---> |--- ---| |=== ===| /=== ===/ <~~~ ~~~> <~~~>
 
 """).trim().split(Regex("""\s+"""))
 
@@ -105,6 +105,7 @@ class LigaturesLimitedSettings : PersistentStateComponent<LigaturesLimitedSettin
     "====>"  to /* language=regexp */ "={4,}>",
     "<====>" to /* language=regexp */ "<={4,}>",
     "<---"   to /* language=regexp */ "<-{3,}",
+    "----"   to /* language=regexp */ "-{4,}",
     "--->"   to /* language=regexp */ "-{3,}>",
     "<--->"  to /* language=regexp */ "<-{3,}>",
     "|---"   to /* language=regexp */ "\\|-{3,}",


### PR DESCRIPTION
Recognize as a ligature four or more dashes, by themselves, without a leading `<` or trailing `>`.